### PR TITLE
Create LaTeX class `usgc-invoice` to separate form and content

### DIFF
--- a/usgc-invoice.cls
+++ b/usgc-invoice.cls
@@ -1,0 +1,109 @@
+\ProvidesClass{usgc-invoice}
+\LoadClass{article}
+
+\RequirePackage[letterpaper, margin=1in]{geometry}
+\RequirePackage{longtable}
+\RequirePackage{xcolor}
+
+\renewcommand{\familydefault}{\ttdefault}
+
+% Line item counter/generator
+\newcounter{linenum}
+\newcommand{\N}{%
+  \stepcounter{linenum}%
+  \thelinenum
+}
+
+\newcommand{\USGCAddress}{%
+  \begin{tabular}[t]{@{}l@{}}
+    \textbf{U.S. Graphics Company} \\
+    PO Box 32871 \\
+    Phoenix, AZ 85064\\
+    billing@usgraphics.com\\
+  \end{tabular}%
+}
+
+\newcommand{\invoiceData}[3]{%
+  \raisebox{\dimexpr-\height+\ht\strutbox}[0pt][0pt]{%
+    \begin{tabular}{|ll|}
+      \hline
+      \textbf{Invoice \#:}      & #1 \\
+      \textbf{Invoice Created:} & #2 \\
+      \textbf{Invoice Due:}     & #3 \\
+      \hline
+    \end{tabular}%
+  }%
+}
+
+\newcommand{\header}[3]{%
+  \noindent
+  \USGCAddress
+  \hfill
+  \invoiceData{#1}{#2}{#3}%
+  \vspace{20pt}%
+}
+
+\newenvironment{company}{%
+  \begingroup
+  \setlength{\parindent}{0pt}
+  \obeylines
+  \noindent
+  \textbf{Billed To:}
+}{
+  \endgroup
+  \vspace{22pt}
+}
+
+\newcommand{\order}[3]{%
+  \def\orderNumber{#1} % Save it to be used in the table
+  \noindent
+  \begin{tabular}{@{}ll@{}}
+  Order No.:     & #1 \\
+  Checkout No.:  & #2 \\
+  Purchase Date: & #3
+  \end{tabular}
+  \vspace{10pt}
+}
+
+\newenvironment{orderTable}[1][\orderNumber]{%
+  % Reset counter before table
+  \setcounter{linenum}{0}
+
+  % Invoice table with SKU column
+  % \begin{longtable}{r l p{3in} @{\hspace{2.3em}} r r r}
+  \begin{longtable}{r l p{3in} @{\hspace{24pt}} r r r}
+    \multicolumn{6}{c}{\textbf{Order #1}}\\
+    \textbf{\#} & \textbf{SKU} & \textbf{Desc.} & \textbf{Unit Rate} & \textbf{Count} & \textbf{Amount (USD)}\\
+    \hline
+}{%
+  \end{longtable}
+}
+
+\newcommand{\totals}[7]{%
+  \hline
+  \multicolumn{5}{r}{Subtotal} & #1\\
+  \multicolumn{5}{r}{Discount} & #2\\
+  \hline
+  \multicolumn{5}{r}{Net Sales Total} & #3\\
+  \multicolumn{5}{r}{Tax} & #4\\
+  \hline\hline
+  \multicolumn{5}{r}{\textbf{Total}} & \textbf{#5}\\
+  \multicolumn{6}{r}{}\\
+  \multicolumn{6}{c}{Invoice Status: P A I D}\\
+  \multicolumn{6}{r}{}\\
+  \hline
+  \multicolumn{5}{r}{Paid} & #6\\
+  \hline
+  \multicolumn{5}{r}{\textbf{Balance}} & \textbf{#7}\\
+}
+
+\newcommand{\footer}[1]{%
+  \noindent
+  \begin{tabular}{@{}ll@{}}
+    Payment Method: & #1\\
+  \end{tabular}
+  \center ***
+  \center Thank you for your business.
+  \center U.S. Graphics Company%
+}
+

--- a/usgc-invoice.tex
+++ b/usgc-invoice.tex
@@ -1,95 +1,40 @@
-\documentclass{article}
-\usepackage[letterpaper, margin=1in]{geometry}
-\usepackage{longtable}
-\usepackage{xcolor}
-\renewcommand{\familydefault}{\ttdefault}
-
-% Line item counter/generator
-\newcounter{linenum}
-\newcommand{\lineitem}[5]{%
-    % #1 = SKU, #2 = Description, #3 = Unit Rate, #4 = Count, #5 = Amount
-    \stepcounter{linenum}%
-    \thelinenum & #1 & #2 & & #3 & #4 & #5\\
-}
+\documentclass{usgc-invoice}
 
 \begin{document}
-% Header
-\noindent
-\begin{tabular}[t]{@{}l@{}}
-\textbf{U.S. Graphics Company} \\
-PO Box 32871 \\
-Phoenix, AZ 85064\\
-billing@usgraphics.com\\
-\end{tabular}%
-\hfill%
-\raisebox{\dimexpr-\height+\ht\strutbox}[0pt][0pt]{%
-\begin{tabular}{|ll|}
-\hline
-\textbf{Invoice \#:} & 102-AA7JHF2E \\
-\textbf{Invoice Created:} & Sep 16, 2025 \\
-\textbf{Invoice Due:} & Oct 15, 2025 \\
-\hline
-\end{tabular}}
 
-\vspace{20pt}
+\header{102-AA7JHF2E}
+       {Sep 16, 2025} % Invoice created
+       {Oct 15, 2025} % Invoice due
 
-% To Company
-\noindent\textbf{Billed To:}\\
-% Free form information provided by the customer (must escape for LaTeX)
-European Graphics GmbH.\\
-404 Nonexistentstrasse, Unit 2B,\\
-70128, Stuttgart, Germany\\
-P.O. No. 100-20358238\\
-VAT ID 82382101\\
+\begin{company}
+  European Graphics GmbH.
+  404 Nonexistentstrasse, Unit 2B,
+  70128, Stuttgart, Germany
+  P.O. No. 100-20358238
+  VAT ID 82382101
+\end{company}
 
-\vspace{10pt}
+\order{TZR29K0}
+      {RXL02W4WKQZK6WN4NY5K}
+      {Sep 16, 2025}
 
-\noindent
-\begin{tabular}{@{}ll@{}}
-Order No.: & TZR29K0 \\
-Checkout No.: & RXL02W4WKQZK6WN4NY5K \\
-Purchase Date: & Sep 16, 2025
-\end{tabular}
+\begin{orderTable}
+  \N & FX-400 & Berkeley Mono Startup           & 495.00 & 1 & 495.00 \\
+  \N & MX-004 & Berkeley Mono Standard Fonts    &   0.00 & 1 &   0.00 \\
+  \N & MX-017 & Berkeley Mono Ligatures         &   0.00 & 1 &   0.00 \\
+  \N & TS-024 & Berkeley Mono Standard Compiler &   0.00 & 1 &   0.00 \\
+  \N & MX-014 & Berkeley Mono Web Fonts         & 295.00 & 1 & 295.00 \\
+  \N & MX-020 & Berkeley Mono App License       & 395.00 & 1 & 395.00 \\
+  \totals
+    {1185.00}   % Subtotal
+    {-90.00}    % Discount
+    {1095.00}   % Net sales total
+    {0.00}      % Tax
+    {1095.00}   % Total
+    {-1095.00}  % Paid
+    {0.00}      % Balance
+\end{orderTable}
 
-\vspace{10pt}
+\footer{VISA x 4242}
 
-% Reset counter before table
-\setcounter{linenum}{0}
-
-% Invoice table with SKU column
-\begin{longtable}{r l p{3in} l r r r}
-\multicolumn{7}{c}{\textbf{Order TZR29K0}}\\
-\textbf{\#} & \textbf{SKU} & \textbf{Desc.} & & \textbf{Unit Rate} & \textbf{Count} & \textbf{Amount (USD)}\\
-\hline
-\lineitem{FX-400}{Berkeley Mono Startup}{495.00}{1}{495.00}
-\lineitem{MX-004}{Berkeley Mono Standard Fonts}{0.00}{1}{0.00}
-\lineitem{MX-017}{Berkeley Mono Ligatures}{0.00}{1}{0.00}
-\lineitem{TS-024}{Berkeley Mono Standard Compiler}{0.00}{1}{0.00}
-\lineitem{MX-014}{Berkeley Mono Web Fonts}{295.00}{1}{295.00}
-\lineitem{MX-020}{Berkeley Mono App License}{395.00}{1}{395.00}
-\hline
-\multicolumn{6}{r}{Subtotal} & 1185.00\\
-\multicolumn{6}{r}{Discount} & -90.00\\
-\hline
-\multicolumn{6}{r}{Net Sales Total} & 1095.00\\
-\multicolumn{6}{r}{Tax} & 0.00\\
-\hline\hline
-\multicolumn{6}{r}{\textbf{Total}} & \textbf{1095.00}\\
-\multicolumn{7}{r}{}\\
-\multicolumn{7}{c}{Invoice Status: P A I D}\\
-\multicolumn{7}{r}{}\\
-\hline
-\multicolumn{6}{r}{Paid} & -1095.00\\
-\hline
-\multicolumn{6}{r}{\textbf{Balance}} & \textbf{0.00}\\
-\end{longtable}
-
-% Footer
-\noindent
-\begin{tabular}{@{}ll@{}}
-Payment Method: & VISA x 4242\\
-\end{tabular}
-\center ***
-\center Thank you for your business.
-\center U.S. Graphics Company
 \end{document}


### PR DESCRIPTION
Move the formatting code to a dedicated `usgc-invoice` class. Following LaTeX philosophy, this allows the `*.tex` file to focus on the content.

No changes in output expected:
[old.pdf](https://github.com/user-attachments/files/23964570/old.pdf)
[new.pdf](https://github.com/user-attachments/files/23964572/new.pdf)